### PR TITLE
fix: allow function for initialize state

### DIFF
--- a/src/useSessionStorage.test.ts
+++ b/src/useSessionStorage.test.ts
@@ -94,6 +94,28 @@ describe(useSessionStorage.name, () => {
     expect(sessionStorage.getItem(key)).toBe(`{"foo":"bar","one":1}`);
   });
 
+  test("function", () => {
+    const key = "text/function";
+    const { result } = renderHook(() =>
+      useSessionStorage(key, () => {
+        return {
+          foo: "bar",
+          one: 1,
+        };
+      })
+    );
+
+    expect(result.current[0]).toStrictEqual({ foo: "bar", one: 1 });
+    expect(sessionStorage.getItem(key)).toBe(null);
+
+    act(() => {
+      result.current[1]({ foo: "baz", one: 2 });
+    });
+
+    expect(result.current[0]).toStrictEqual({ foo: "baz", one: 2 });
+    expect(sessionStorage.getItem(key)).toBe(`{"foo":"baz","one":2}`);
+  });
+
   test("it should return initial value if JSON.parse() is failed", () => {
     const key = "test/invalid-value";
     sessionStorage.setItem(key, "{one:1}");

--- a/src/useSessionStorage.ts
+++ b/src/useSessionStorage.ts
@@ -1,7 +1,12 @@
 import { useState, useCallback } from "react";
 
-export const useSessionStorage = <T>(key: string, initialValue: T) => {
+export const useSessionStorage = <T>(
+  key: string,
+  initialState: T | (() => T)
+) => {
   const [state, setState] = useState(() => {
+    const initialValue =
+      initialState instanceof Function ? initialState() : initialState;
     if (typeof window === "undefined") {
       return initialValue;
     }


### PR DESCRIPTION
Enable to use function to initialize state like [useState](https://reactjs.org/docs/hooks-reference.html#lazy-initial-state)
