### PR TITLE
feat: add useAsyncFn and useMounted

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 React utility parts
 
+## Inpired
+
+- [react-use](https://github.com/streamich/react-use)
+
 ## LICENSE
 
 [MIT](LICENSE)

--- a/src/useAsyncFn.test.ts
+++ b/src/useAsyncFn.test.ts
@@ -1,0 +1,100 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import { useAsyncFn } from "./useAsyncFn";
+
+describe(useAsyncFn.name, () => {
+  test("it should return initialState", () => {
+    const { result } = renderHook(() => useAsyncFn(() => Promise.resolve()));
+
+    expect(result.current[0]).toEqual({
+      loading: false,
+    });
+  });
+
+  test("it should set return value of async function", async () => {
+    const fn = jest.fn().mockResolvedValue("success");
+    const { result } = renderHook(() =>
+      useAsyncFn(fn, { loading: false, value: "" })
+    );
+
+    expect(result.current[0]).toEqual({
+      loading: false,
+      value: "",
+    });
+
+    await act(async () => {
+      await result.current[1]();
+    });
+
+    expect(result.current[0]).toEqual({
+      loading: false,
+      value: "success",
+    });
+
+    expect(fn.mock.calls.length).toBe(1);
+  });
+
+  test("it should not set value if async function return promise rejected", async () => {
+    const fn = jest.fn().mockRejectedValue("fail");
+    const { result } = renderHook(() =>
+      useAsyncFn(fn, { loading: false, value: "" })
+    );
+
+    await act(async () => {
+      await expect(result.current[1]()).rejects.toBe("fail");
+    });
+
+    expect(result.current[0]).toEqual({
+      loading: false,
+    });
+
+    expect(fn.mock.calls.length).toBe(1);
+  });
+
+  test("it should set state by last called async function", async () => {
+    const promiseList: { resolve: () => void }[] = [];
+    const fn = jest
+      .fn()
+      .mockImplementationOnce(() => {
+        return new Promise((resolve) => {
+          promiseList.push({ resolve: () => resolve("foo") });
+        });
+      })
+      .mockImplementation(() => {
+        return new Promise((resolve) => {
+          promiseList.push({ resolve: () => resolve("bar") });
+        });
+      });
+
+    const { result } = renderHook(() => useAsyncFn(fn));
+
+    let call1: Promise<any>;
+    act(() => {
+      call1 = result.current[1]();
+    });
+
+    expect(result.current[0]).toEqual({ loading: true });
+    expect(fn.mock.calls.length).toBe(1);
+
+    let call2: Promise<any>;
+    act(() => {
+      result.current[1]();
+    });
+
+    expect(result.current[0]).toEqual({ loading: true });
+    expect(fn.mock.calls.length).toBe(2);
+
+    await act(async () => {
+      promiseList[1].resolve();
+      await call2;
+    });
+
+    expect(result.current[0]).toEqual({ loading: false, value: "bar" });
+
+    await act(async () => {
+      promiseList[0].resolve();
+      await call1;
+    });
+
+    expect(result.current[0]).toEqual({ loading: false, value: "bar" });
+  });
+});

--- a/src/useAsyncFn.ts
+++ b/src/useAsyncFn.ts
@@ -1,0 +1,46 @@
+import { useCallback, useRef, useState } from "react";
+import { useMounted } from "./useMounted";
+
+type PromiseType<T extends Promise<any>> = T extends Promise<infer U>
+  ? U
+  : never;
+
+type AsyncFn = (...args: any[]) => Promise<any>;
+
+type UseAsyncFnState<T extends AsyncFn> = {
+  loading: boolean;
+  value?: PromiseType<ReturnType<T>>;
+};
+
+export const useAsyncFn = <T extends AsyncFn>(
+  asyncFn: T,
+  initialState: UseAsyncFnState<T> = { loading: false }
+) => {
+  const lastCallId = useRef(0);
+  const isMounted = useMounted();
+
+  const [state, setState] = useState(initialState);
+
+  const fn = useCallback(
+    (...args: Parameters<T>) => {
+      const callId = ++lastCallId.current;
+      setState((prev) => ({ ...prev, loading: true }));
+
+      return asyncFn(...args)
+        .then((value) => {
+          isMounted() &&
+            callId === lastCallId.current &&
+            setState({ loading: false, value });
+        })
+        .catch((error) => {
+          isMounted() &&
+            callId === lastCallId.current &&
+            setState({ loading: false });
+          return Promise.reject(error);
+        });
+    },
+    [asyncFn, isMounted]
+  );
+
+  return [state, fn] as const;
+};

--- a/src/useMounted.test.ts
+++ b/src/useMounted.test.ts
@@ -1,0 +1,18 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { useMounted } from "./useMounted";
+
+describe(useMounted.name, () => {
+  test("mounted", () => {
+    const { result } = renderHook(() => useMounted());
+
+    expect(result.current()).toBe(true);
+  });
+
+  test("unmounted", () => {
+    const { result, unmount } = renderHook(() => useMounted());
+
+    unmount();
+
+    expect(result.current()).toBe(false);
+  });
+});

--- a/src/useMounted.ts
+++ b/src/useMounted.ts
@@ -1,0 +1,17 @@
+import { useCallback, useEffect, useRef } from "react";
+
+export const useMounted = () => {
+  const mounted = useRef(false);
+
+  useEffect(() => {
+    mounted.current = true;
+
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const fn = useCallback(() => mounted.current, []);
+
+  return fn;
+};


### PR DESCRIPTION
`useAsyncFn` set state return value of async function.

```typescript
const [state, fn] = useAsyncFn(async () => {
  const result = await fetchData();
  return result;
});

useEffect(() => {
  fn();
}, [fn]);

if (state.loading) {
  return (
    <div>loading</div>
  );
}
return (
  <div>
    {result.value}
  </div>
);
```

`useMounted` is utility hook to check mounted/unmounted.

```typescript
const [state, setState] = useState();
const isMounted = useMounted();

const fn = useCallback(async () => {
  const result = await fetchData();
  if (!isMounted()) {
    return;
  }

  setState(result);
});
```
